### PR TITLE
mention additional arguments in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ var acorn = require( 'acorn' );
 ast = acorn.parse( sourceCode, options ); // https://github.com/marijnh/acorn
 
 walk( ast, {
-  enter: function ( node, parent ) {
+  enter: function ( node, parent, prop, index ) {
     // some code happens
   },
-  leave: function ( node, parent ) {
+  leave: function ( node, parent, prop, index ) {
   	// some code happens
   }
 });

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ npm i estree-walker
 var walk = require( 'estree-walker' ).walk;
 var acorn = require( 'acorn' );
 
-ast = acorn.parse( sourceCode, options ); // https://github.com/marijnh/acorn
+ast = acorn.parse( sourceCode, options ); // https://github.com/acornjs/acorn
 
 walk( ast, {
   enter: function ( node, parent, prop, index ) {


### PR DESCRIPTION
The `prop` and `index` arguments that are passed to the visitor callbacks would have saved me a bit of hair pulling in eslint-plugin-svelte3 if only they had been documented.