### PR TITLE
relax node type from `Node` to `BaseNode`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,15 +1,15 @@
-import { Node } from "estree";
+import { BaseNode } from "estree";
 
 type WalkerContext = {
 	skip: () => void;
 	remove: () => void;
-	replace: (node: Node) => void;
+	replace: (node: BaseNode) => void;
 };
 
 type WalkerHandler = (
 	this: WalkerContext,
-	node: Node,
-	parent: Node,
+	node: BaseNode,
+	parent: BaseNode,
 	key: string,
 	index: number
 ) => void
@@ -19,20 +19,20 @@ type Walker = {
 	leave?: WalkerHandler;
 }
 
-export function walk(ast: Node, { enter, leave }: Walker) {
+export function walk(ast: BaseNode, { enter, leave }: Walker) {
 	return visit(ast, null, enter, leave);
 }
 
 let should_skip = false;
 let should_remove = false;
-let replacement: Node = null;
+let replacement: BaseNode = null;
 const context: WalkerContext = {
 	skip: () => should_skip = true,
 	remove: () => should_remove = true,
-	replace: (node: Node) => replacement = node
+	replace: (node: BaseNode) => replacement = node
 };
 
-function replace(parent: any, prop: string, index: number, node: Node) {
+function replace(parent: any, prop: string, index: number, node: BaseNode) {
 	if (parent) {
 		if (index !== null) {
 			parent[prop][index] = node;
@@ -53,8 +53,8 @@ function remove(parent: any, prop: string, index: number) {
 }
 
 function visit(
-	node: Node,
-	parent: Node,
+	node: BaseNode,
+	parent: BaseNode,
 	enter: WalkerHandler,
 	leave: WalkerHandler,
 	prop?: string,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,13 +1,13 @@
-import { Node } from "estree";
+import { BaseNode } from "estree";
 declare type WalkerContext = {
     skip: () => void;
     remove: () => void;
-    replace: (node: Node) => void;
+    replace: (node: BaseNode) => void;
 };
-declare type WalkerHandler = (this: WalkerContext, node: Node, parent: Node, key: string, index: number) => void;
+declare type WalkerHandler = (this: WalkerContext, node: BaseNode, parent: BaseNode, key: string, index: number) => void;
 declare type Walker = {
     enter?: WalkerHandler;
     leave?: WalkerHandler;
 };
-export declare function walk(ast: Node, { enter, leave }: Walker): import("estree").Identifier | import("estree").SimpleLiteral | import("estree").RegExpLiteral | import("estree").Program | import("estree").FunctionDeclaration | import("estree").FunctionExpression | import("estree").ArrowFunctionExpression | import("estree").SwitchCase | import("estree").CatchClause | import("estree").VariableDeclarator | import("estree").ExpressionStatement | import("estree").BlockStatement | import("estree").EmptyStatement | import("estree").DebuggerStatement | import("estree").WithStatement | import("estree").ReturnStatement | import("estree").LabeledStatement | import("estree").BreakStatement | import("estree").ContinueStatement | import("estree").IfStatement | import("estree").SwitchStatement | import("estree").ThrowStatement | import("estree").TryStatement | import("estree").WhileStatement | import("estree").DoWhileStatement | import("estree").ForStatement | import("estree").ForInStatement | import("estree").ForOfStatement | import("estree").VariableDeclaration | import("estree").ClassDeclaration | import("estree").ThisExpression | import("estree").ArrayExpression | import("estree").ObjectExpression | import("estree").YieldExpression | import("estree").UnaryExpression | import("estree").UpdateExpression | import("estree").BinaryExpression | import("estree").AssignmentExpression | import("estree").LogicalExpression | import("estree").MemberExpression | import("estree").ConditionalExpression | import("estree").SimpleCallExpression | import("estree").NewExpression | import("estree").SequenceExpression | import("estree").TemplateLiteral | import("estree").TaggedTemplateExpression | import("estree").ClassExpression | import("estree").MetaProperty | import("estree").AwaitExpression | import("estree").Property | import("estree").Super | import("estree").TemplateElement | import("estree").SpreadElement | import("estree").ObjectPattern | import("estree").ArrayPattern | import("estree").RestElement | import("estree").AssignmentPattern | import("estree").ClassBody | import("estree").MethodDefinition | import("estree").ImportDeclaration | import("estree").ExportNamedDeclaration | import("estree").ExportDefaultDeclaration | import("estree").ExportAllDeclaration | import("estree").ImportSpecifier | import("estree").ImportDefaultSpecifier | import("estree").ImportNamespaceSpecifier | import("estree").ExportSpecifier;
+export declare function walk(ast: BaseNode, { enter, leave }: Walker): BaseNode;
 export {};


### PR DESCRIPTION
In `@types/estree`, `Node` is a discriminated union type for all known nodes. However, parsing JSX (or other syntactic additions) requires additional node types. This library copes with this just fine, as evidenced by this test:

https://github.com/Rich-Harris/estree-walker/blob/2f3d7e47e6a86e4d1c5d43c4e404755871e45b20/test/test.ts#L5

However, this library declares the types of `walk` too restrictively. It could use `BaseNode` instead, which would make it more flexible when used from TS.