### PR TITLE
Move from sync to async

### DIFF
--- a/src/estree-walker.js
+++ b/src/estree-walker.js
@@ -1,5 +1,5 @@
-function walk(ast, { enter, leave }) {
-	return visit(ast, null, enter, leave);
+async function walk(ast, { enter, leave }) {
+	return await visit(ast, null, enter, leave);
 }
 
 let should_skip = false;
@@ -31,7 +31,7 @@ function remove(parent, prop, index) {
 	}
 }
 
-function visit(
+async function visit(
 	node,
 	parent,
 	enter,
@@ -48,7 +48,7 @@ function visit(
 			should_remove = false;
 			replacement = null;
 
-			enter.call(context, node, parent, prop, index);
+			await enter.call(context, node, parent, prop, index);
 
 			if (replacement) {
 				node = replacement;
@@ -89,7 +89,7 @@ function visit(
 			}
 
 			else if (value !== null && typeof value.type === 'string') {
-				visit(value, node, enter, leave, key, null);
+				await visit(value, node, enter, leave, key, null);
 			}
 		}
 
@@ -99,7 +99,7 @@ function visit(
 			replacement = null;
 			should_remove = false;
 
-			leave.call(context, node, parent, prop, index);
+			await leave.call(context, node, parent, prop, index);
 
 			if (replacement) {
 				node = replacement;

--- a/src/estree-walker.js
+++ b/src/estree-walker.js
@@ -80,7 +80,7 @@ async function visit(
 			else if (Array.isArray(value)) {
 				for (let j = 0, k = 0; j < value.length; j += 1, k += 1) {
 					if (value[j] !== null && typeof value[j].type === 'string') {
-						if (!visit(value[j], node, enter, leave, key, k)) {
+						if (!await visit(value[j], node, enter, leave, key, k)) {
 							// removed
 							j--;
 						}

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,15 +12,15 @@ type WalkerHandler = (
 	parent: BaseNode,
 	key: string,
 	index: number
-) => void
+) => Promise<void>
 
 type Walker = {
 	enter?: WalkerHandler;
 	leave?: WalkerHandler;
 }
 
-export function walk(ast: BaseNode, { enter, leave }: Walker) {
-	return visit(ast, null, enter, leave);
+export async function walk(ast: BaseNode, { enter, leave }: Walker): Promise<BaseNode> {
+	return await visit(ast, null, enter, leave);
 }
 
 let should_skip = false;
@@ -52,14 +52,14 @@ function remove(parent: any, prop: string, index: number) {
 	}
 }
 
-function visit(
+async function visit(
 	node: BaseNode,
 	parent: BaseNode,
 	enter: WalkerHandler,
 	leave: WalkerHandler,
 	prop?: string,
 	index?: number
-) {
+): Promise<BaseNode> {
 	if (node) {
 		if (enter) {
 			const _should_skip = should_skip;
@@ -69,7 +69,7 @@ function visit(
 			should_remove = false;
 			replacement = null;
 
-			enter.call(context, node, parent, prop, index);
+			await enter.call(context, node, parent, prop, index);
 
 			if (replacement) {
 				node = replacement;
@@ -110,7 +110,7 @@ function visit(
 			}
 
 			else if (value !== null && typeof value.type === 'string') {
-				visit(value, node, enter, leave, key, null);
+				await visit(value, node, enter, leave, key, null);
 			}
 		}
 
@@ -120,7 +120,7 @@ function visit(
 			replacement = null;
 			should_remove = false;
 
-			leave.call(context, node, parent, prop, index);
+			await leave.call(context, node, parent, prop, index);
 
 			if (replacement) {
 				node = replacement;

--- a/src/index.ts
+++ b/src/index.ts
@@ -101,7 +101,7 @@ async function visit(
 			else if (Array.isArray(value)) {
 				for (let j = 0, k = 0; j < value.length; j += 1, k += 1) {
 					if (value[j] !== null && typeof value[j].type === 'string') {
-						if (!visit(value[j], node, enter, leave, key, k)) {
+						if (!await visit(value[j], node, enter, leave, key, k)) {
 							// removed
 							j--;
 						}

--- a/test/test.ts
+++ b/test/test.ts
@@ -2,34 +2,34 @@ const assert = require("assert");
 const { walk } = require("..");
 
 describe("estree-walker", () => {
-  // it("walks a malformed node", async () => {
-  //   const block = [
-  //     {
-  //       type: "Foo",
-  //       answer: undefined
-  //     },
-  //     {
-  //       type: "Foo",
-  //       answer: {
-  //         type: "Answer",
-  //         value: 42
-  //       }
-  //     }
-  //   ];
+  it("walks a malformed node", async () => {
+    const block = [
+      {
+        type: "Foo",
+        answer: undefined
+      },
+      {
+        type: "Foo",
+        answer: {
+          type: "Answer",
+          value: 42
+        }
+      }
+    ];
 
-  //   let answer;
+    let answer;
 
-  //   await walk(
-  //     { type: "Test", block },
-  //     {
-  //       enter(node) {
-  //         if (node.type === "Answer") answer = node;
-  //       }
-  //     }
-  //   );
+    await walk(
+      { type: "Test", block },
+      {
+        enter(node) {
+          if (node.type === "Answer") answer = node;
+        }
+      }
+    );
 
-  //   assert.equal(answer, block[1].answer);
-  // });
+    assert.equal(answer, block[1].answer);
+  });
 
   it("walks an AST", async () => {
     const ast = {
@@ -66,8 +66,6 @@ describe("estree-walker", () => {
         left.push(node);
       }
 		});
-		
-		console.log('walk done', {entered, left});
 
     assert.deepEqual(entered, [
       ast,
@@ -92,283 +90,283 @@ describe("estree-walker", () => {
     ]);
   });
 
-  // it("handles null literals", async () => {
-  //   const ast = {
-  //     type: "Program",
-  //     start: 0,
-  //     end: 8,
-  //     body: [
-  //       {
-  //         type: "ExpressionStatement",
-  //         start: 0,
-  //         end: 5,
-  //         expression: {
-  //           type: "Literal",
-  //           start: 0,
-  //           end: 4,
-  //           value: null,
-  //           raw: "null"
-  //         }
-  //       },
-  //       {
-  //         type: "ExpressionStatement",
-  //         start: 6,
-  //         end: 8,
-  //         expression: {
-  //           type: "Literal",
-  //           start: 6,
-  //           end: 7,
-  //           value: 1,
-  //           raw: "1"
-  //         }
-  //       }
-  //     ],
-  //     sourceType: "module"
-  //   };
+  it("handles null literals", async () => {
+    const ast = {
+      type: "Program",
+      start: 0,
+      end: 8,
+      body: [
+        {
+          type: "ExpressionStatement",
+          start: 0,
+          end: 5,
+          expression: {
+            type: "Literal",
+            start: 0,
+            end: 4,
+            value: null,
+            raw: "null"
+          }
+        },
+        {
+          type: "ExpressionStatement",
+          start: 6,
+          end: 8,
+          expression: {
+            type: "Literal",
+            start: 6,
+            end: 7,
+            value: 1,
+            raw: "1"
+          }
+        }
+      ],
+      sourceType: "module"
+    };
 
-  //   await walk(ast, {
-  //     enter() {},
-  //     leave() {}
-  //   });
+    await walk(ast, {
+      enter() {},
+      leave() {}
+    });
 
-  //   assert.ok(true);
-  // });
+    assert.ok(true);
+  });
 
-  // it("allows walk() to be invoked within a walk, without context corruption", async () => {
-  //   const ast = {
-  //     type: "Program",
-  //     start: 0,
-  //     end: 8,
-  //     body: [
-  //       {
-  //         type: "ExpressionStatement",
-  //         start: 0,
-  //         end: 6,
-  //         expression: {
-  //           type: "BinaryExpression",
-  //           start: 0,
-  //           end: 5,
-  //           left: {
-  //             type: "Identifier",
-  //             start: 0,
-  //             end: 1,
-  //             name: "a"
-  //           },
-  //           operator: "+",
-  //           right: {
-  //             type: "Identifier",
-  //             start: 4,
-  //             end: 5,
-  //             name: "b"
-  //           }
-  //         }
-  //       }
-  //     ],
-  //     sourceType: "module"
-  //   };
+  it("allows walk() to be invoked within a walk, without context corruption", async () => {
+    const ast = {
+      type: "Program",
+      start: 0,
+      end: 8,
+      body: [
+        {
+          type: "ExpressionStatement",
+          start: 0,
+          end: 6,
+          expression: {
+            type: "BinaryExpression",
+            start: 0,
+            end: 5,
+            left: {
+              type: "Identifier",
+              start: 0,
+              end: 1,
+              name: "a"
+            },
+            operator: "+",
+            right: {
+              type: "Identifier",
+              start: 4,
+              end: 5,
+              name: "b"
+            }
+          }
+        }
+      ],
+      sourceType: "module"
+    };
 
-  //   const identifiers = [];
+    const identifiers = [];
 
-  //   await walk(ast, {
-  //     async enter(node) {
-  //       if (node.type === "ExpressionStatement") {
-  //         await walk(node, {
-  //           enter() {
-  //             this.skip();
-  //           }
-  //         });
-  //       }
+    await walk(ast, {
+      async enter(node) {
+        if (node.type === "ExpressionStatement") {
+          await walk(node, {
+            enter() {
+              this.skip();
+            }
+          });
+        }
 
-  //       if (node.type === "Identifier") {
-  //         identifiers.push(node.name);
-  //       }
-  //     }
-  //   });
+        if (node.type === "Identifier") {
+          identifiers.push(node.name);
+        }
+      }
+    });
 
-  //   assert.deepEqual(identifiers, ["a", "b"]);
-  // });
+    assert.deepEqual(identifiers, ["a", "b"]);
+  });
 
-  // it("replaces a node", async () => {
-  //   const phases = ["enter", "leave"];
-  //   for await (const phase of phases) {
-  //     const ast = {
-  //       type: "Program",
-  //       start: 0,
-  //       end: 8,
-  //       body: [
-  //         {
-  //           type: "ExpressionStatement",
-  //           start: 0,
-  //           end: 6,
-  //           expression: {
-  //             type: "BinaryExpression",
-  //             start: 0,
-  //             end: 5,
-  //             left: {
-  //               type: "Identifier",
-  //               start: 0,
-  //               end: 1,
-  //               name: "a"
-  //             },
-  //             operator: "+",
-  //             right: {
-  //               type: "Identifier",
-  //               start: 4,
-  //               end: 5,
-  //               name: "b"
-  //             }
-  //           }
-  //         }
-  //       ],
-  //       sourceType: "module"
-  //     };
+  it("replaces a node", async () => {
+    const phases = ["enter", "leave"];
+    for await (const phase of phases) {
+      const ast = {
+        type: "Program",
+        start: 0,
+        end: 8,
+        body: [
+          {
+            type: "ExpressionStatement",
+            start: 0,
+            end: 6,
+            expression: {
+              type: "BinaryExpression",
+              start: 0,
+              end: 5,
+              left: {
+                type: "Identifier",
+                start: 0,
+                end: 1,
+                name: "a"
+              },
+              operator: "+",
+              right: {
+                type: "Identifier",
+                start: 4,
+                end: 5,
+                name: "b"
+              }
+            }
+          }
+        ],
+        sourceType: "module"
+      };
 
-  //     const forty_two = {
-  //       type: "Literal",
-  //       value: 42,
-  //       raw: "42"
-  //     };
+      const forty_two = {
+        type: "Literal",
+        value: 42,
+        raw: "42"
+      };
 
-  //     await walk(ast, {
-  //       [phase](node) {
-  //         if (node.type === "Identifier" && node.name === "b") {
-  //           this.replace(forty_two);
-  //         }
-  //       }
-  //     });
+      await walk(ast, {
+        [phase](node) {
+          if (node.type === "Identifier" && node.name === "b") {
+            this.replace(forty_two);
+          }
+        }
+      });
 
-  //     assert.equal(ast.body[0].expression.right, forty_two);
-  //   }
-  // });
+      assert.equal(ast.body[0].expression.right, forty_two);
+    }
+  });
 
-  // it("replaces a top-level node", async () => {
-  //   const ast = {
-  //     type: "Identifier",
-  //     name: "answer"
-  //   };
+  it("replaces a top-level node", async () => {
+    const ast = {
+      type: "Identifier",
+      name: "answer"
+    };
 
-  //   const forty_two = {
-  //     type: "Literal",
-  //     value: 42,
-  //     raw: "42"
-  //   };
+    const forty_two = {
+      type: "Literal",
+      value: 42,
+      raw: "42"
+    };
 
-  //   const node = await walk(ast, {
-  //     enter(node) {
-  //       if (node.type === "Identifier" && node.name === "answer") {
-  //         this.replace(forty_two);
-  //       }
-  //     }
-  //   });
+    const node = await walk(ast, {
+      enter(node) {
+        if (node.type === "Identifier" && node.name === "answer") {
+          this.replace(forty_two);
+        }
+      }
+    });
 
-  //   assert.equal(node, forty_two);
-  // });
+    assert.equal(node, forty_two);
+  });
 
-  // it("removes a node property", async () => {
-  //   const phases = ["enter", "leave"];
-  //   for await (const phase of phases) {
-  //     const ast = {
-  //       type: "Program",
-  //       start: 0,
-  //       end: 8,
-  //       body: [
-  //         {
-  //           type: "ExpressionStatement",
-  //           start: 0,
-  //           end: 6,
-  //           expression: {
-  //             type: "BinaryExpression",
-  //             start: 0,
-  //             end: 5,
-  //             left: {
-  //               type: "Identifier",
-  //               start: 0,
-  //               end: 1,
-  //               name: "a"
-  //             },
-  //             operator: "+",
-  //             right: {
-  //               type: "Identifier",
-  //               start: 4,
-  //               end: 5,
-  //               name: "b"
-  //             }
-  //           }
-  //         }
-  //       ],
-  //       sourceType: "module"
-  //     };
+  it("removes a node property", async () => {
+    const phases = ["enter", "leave"];
+    for await (const phase of phases) {
+      const ast = {
+        type: "Program",
+        start: 0,
+        end: 8,
+        body: [
+          {
+            type: "ExpressionStatement",
+            start: 0,
+            end: 6,
+            expression: {
+              type: "BinaryExpression",
+              start: 0,
+              end: 5,
+              left: {
+                type: "Identifier",
+                start: 0,
+                end: 1,
+                name: "a"
+              },
+              operator: "+",
+              right: {
+                type: "Identifier",
+                start: 4,
+                end: 5,
+                name: "b"
+              }
+            }
+          }
+        ],
+        sourceType: "module"
+      };
 
-  //     await walk(ast, {
-  //       [phase](node) {
-  //         if (node.type === "Identifier" && node.name === "b") {
-  //           this.remove();
-  //         }
-  //       }
-  //     });
+      await walk(ast, {
+        [phase](node) {
+          if (node.type === "Identifier" && node.name === "b") {
+            this.remove();
+          }
+        }
+      });
 
-  //     assert.equal(ast.body[0].expression.right, undefined);
-  //   }
-  // });
+      assert.equal(ast.body[0].expression.right, undefined);
+    }
+  });
 
-  // it("removes a node from array", async () => {
-	// 	const phases = ['enter', 'leave'];
-	// 	for await (const phase of phases) {
-  //     const ast = {
-  //       type: "Program",
-  //       body: [
-  //         {
-  //           type: "VariableDeclaration",
-  //           declarations: [
-  //             {
-  //               type: "VariableDeclarator",
-  //               id: {
-  //                 type: "Identifier",
-  //                 name: "a"
-  //               },
-  //               init: null
-  //             },
-  //             {
-  //               type: "VariableDeclarator",
-  //               id: {
-  //                 type: "Identifier",
-  //                 name: "b"
-  //               },
-  //               init: null
-  //             },
-  //             {
-  //               type: "VariableDeclarator",
-  //               id: {
-  //                 type: "Identifier",
-  //                 name: "c"
-  //               },
-  //               init: null
-  //             }
-  //           ],
-  //           kind: "let"
-  //         }
-  //       ],
-  //       sourceType: "module"
-  //     };
+  it("removes a node from array", async () => {
+		const phases = ['enter', 'leave'];
+		for await (const phase of phases) {
+      const ast = {
+        type: "Program",
+        body: [
+          {
+            type: "VariableDeclaration",
+            declarations: [
+              {
+                type: "VariableDeclarator",
+                id: {
+                  type: "Identifier",
+                  name: "a"
+                },
+                init: null
+              },
+              {
+                type: "VariableDeclarator",
+                id: {
+                  type: "Identifier",
+                  name: "b"
+                },
+                init: null
+              },
+              {
+                type: "VariableDeclarator",
+                id: {
+                  type: "Identifier",
+                  name: "c"
+                },
+                init: null
+              }
+            ],
+            kind: "let"
+          }
+        ],
+        sourceType: "module"
+      };
 
-  //     const visitedIndex = [];
+      const visitedIndex = [];
 
-  //     walk(ast, {
-  //       [phase](node, parent, key, index) {
-  //         if (node.type === "VariableDeclarator") {
-  //           visitedIndex.push(index);
-  //           if (index === 1) {
-  //             this.remove();
-  //           }
-  //         }
-  //       }
-  //     });
+      await walk(ast, {
+        [phase](node, parent, key, index) {
+          if (node.type === "VariableDeclarator") {
+            visitedIndex.push(index);
+            if (index === 1) {
+              this.remove();
+            }
+          }
+        }
+			});
 
-  //     assert.equal(ast.body[0].declarations.length, 2);
-  //     assert.equal(visitedIndex.length, 3);
-  //     assert.deepEqual(visitedIndex, [0, 1, 2]);
-  //     assert.equal(ast.body[0].declarations[0].id.name, "a");
-  //     assert.equal(ast.body[0].declarations[1].id.name, "c");
-  //   };
-  // });
+      assert.equal(ast.body[0].declarations.length, 2);
+      assert.equal(visitedIndex.length, 3);
+      assert.deepEqual(visitedIndex, [0, 1, 2]);
+      assert.equal(ast.body[0].declarations[0].id.name, "a");
+      assert.equal(ast.body[0].declarations[1].id.name, "c");
+    };
+  });
 });

--- a/test/test.ts
+++ b/test/test.ts
@@ -1,354 +1,374 @@
-const assert = require('assert');
-const { walk } = require('..');
+const assert = require("assert");
+const { walk } = require("..");
 
-describe('estree-walker', () => {
-	it('walks a malformed node', () => {
-		const block = [
-			{
-				type: 'Foo',
-				answer: undefined
-			},
-			{
-				type: 'Foo',
-				answer: {
-					type: 'Answer',
-					value: 42
-				}
-			}
-		];
+describe("estree-walker", () => {
+  // it("walks a malformed node", async () => {
+  //   const block = [
+  //     {
+  //       type: "Foo",
+  //       answer: undefined
+  //     },
+  //     {
+  //       type: "Foo",
+  //       answer: {
+  //         type: "Answer",
+  //         value: 42
+  //       }
+  //     }
+  //   ];
 
-		let answer;
+  //   let answer;
 
-		walk({ type: 'Test', block }, {
-			enter(node) {
-				if (node.type === 'Answer') answer = node;
-			}
+  //   await walk(
+  //     { type: "Test", block },
+  //     {
+  //       enter(node) {
+  //         if (node.type === "Answer") answer = node;
+  //       }
+  //     }
+  //   );
+
+  //   assert.equal(answer, block[1].answer);
+  // });
+
+  it("walks an AST", async () => {
+    const ast = {
+      type: "Program",
+      body: [
+        {
+          type: "VariableDeclaration",
+          declarations: [
+            {
+              type: "VariableDeclarator",
+              id: { type: "Identifier", name: "a" },
+              init: { type: "Literal", value: 1, raw: "1" }
+            },
+            {
+              type: "VariableDeclarator",
+              id: { type: "Identifier", name: "b" },
+              init: { type: "Literal", value: 2, raw: "2" }
+            }
+          ],
+          kind: "var"
+        }
+      ],
+      sourceType: "module"
+    };
+
+    let entered = [];
+    let left = [];
+
+    await walk(ast, {
+      async enter(node) {
+        entered.push(node);
+      },
+      async leave(node) {
+        left.push(node);
+      }
 		});
+		
+		console.log('walk done', {entered, left});
 
-		assert.equal(answer, block[1].answer);
-	});
+    assert.deepEqual(entered, [
+      ast,
+      ast.body[0],
+      ast.body[0].declarations[0],
+      ast.body[0].declarations[0].id,
+      ast.body[0].declarations[0].init,
+      ast.body[0].declarations[1],
+      ast.body[0].declarations[1].id,
+      ast.body[0].declarations[1].init
+    ]);
 
-	it('walks an AST', () => {
-		const ast = {
-			type: 'Program',
-			body: [{
-				type: 'VariableDeclaration',
-				declarations: [
-					{
-						type: 'VariableDeclarator',
-						id: { type: 'Identifier', name: 'a' },
-						init: { type: 'Literal', value: 1, raw: '1' }
-					},
-					{
-						type: 'VariableDeclarator',
-						id: { type: 'Identifier', name: 'b' },
-						init: { type: 'Literal', value: 2, raw: '2' }
-					}
-				],
-				kind: 'var'
-			}],
-			sourceType: 'module'
-		};
+    assert.deepEqual(left, [
+      ast.body[0].declarations[0].id,
+      ast.body[0].declarations[0].init,
+      ast.body[0].declarations[0],
+      ast.body[0].declarations[1].id,
+      ast.body[0].declarations[1].init,
+      ast.body[0].declarations[1],
+      ast.body[0],
+      ast
+    ]);
+  });
 
-		let entered = [];
-		let left = [];
+  // it("handles null literals", async () => {
+  //   const ast = {
+  //     type: "Program",
+  //     start: 0,
+  //     end: 8,
+  //     body: [
+  //       {
+  //         type: "ExpressionStatement",
+  //         start: 0,
+  //         end: 5,
+  //         expression: {
+  //           type: "Literal",
+  //           start: 0,
+  //           end: 4,
+  //           value: null,
+  //           raw: "null"
+  //         }
+  //       },
+  //       {
+  //         type: "ExpressionStatement",
+  //         start: 6,
+  //         end: 8,
+  //         expression: {
+  //           type: "Literal",
+  //           start: 6,
+  //           end: 7,
+  //           value: 1,
+  //           raw: "1"
+  //         }
+  //       }
+  //     ],
+  //     sourceType: "module"
+  //   };
 
-		walk(ast, {
-			enter(node) {
-				entered.push(node);
-			},
-			leave(node) {
-				left.push(node);
-			}
-		});
+  //   await walk(ast, {
+  //     enter() {},
+  //     leave() {}
+  //   });
 
-		assert.deepEqual(entered, [
-			ast,
-			ast.body[0],
-			ast.body[0].declarations[0],
-			ast.body[0].declarations[0].id,
-			ast.body[0].declarations[0].init,
-			ast.body[0].declarations[1],
-			ast.body[0].declarations[1].id,
-			ast.body[0].declarations[1].init
-		]);
+  //   assert.ok(true);
+  // });
 
-		assert.deepEqual(left, [
-			ast.body[0].declarations[0].id,
-			ast.body[0].declarations[0].init,
-			ast.body[0].declarations[0],
-			ast.body[0].declarations[1].id,
-			ast.body[0].declarations[1].init,
-			ast.body[0].declarations[1],
-			ast.body[0],
-			ast
-		]);
-	});
+  // it("allows walk() to be invoked within a walk, without context corruption", async () => {
+  //   const ast = {
+  //     type: "Program",
+  //     start: 0,
+  //     end: 8,
+  //     body: [
+  //       {
+  //         type: "ExpressionStatement",
+  //         start: 0,
+  //         end: 6,
+  //         expression: {
+  //           type: "BinaryExpression",
+  //           start: 0,
+  //           end: 5,
+  //           left: {
+  //             type: "Identifier",
+  //             start: 0,
+  //             end: 1,
+  //             name: "a"
+  //           },
+  //           operator: "+",
+  //           right: {
+  //             type: "Identifier",
+  //             start: 4,
+  //             end: 5,
+  //             name: "b"
+  //           }
+  //         }
+  //       }
+  //     ],
+  //     sourceType: "module"
+  //   };
 
-	it('handles null literals', () => {
-		const ast = {
-			type: 'Program',
-			start: 0,
-			end: 8,
-			body: [
-				{
-					type: 'ExpressionStatement',
-					start: 0,
-					end: 5,
-					expression: {
-						type: 'Literal',
-						start: 0,
-						end: 4,
-						value: null,
-						raw: 'null'
-					}
-				},
-				{
-					type: 'ExpressionStatement',
-					start: 6,
-					end: 8,
-					expression: {
-						type: 'Literal',
-						start: 6,
-						end: 7,
-						value: 1,
-						raw: '1'
-					}
-				}
-			],
-			sourceType: 'module'
-		};
+  //   const identifiers = [];
 
-		walk(ast, {
-			enter() { },
-			leave() { }
-		});
+  //   await walk(ast, {
+  //     async enter(node) {
+  //       if (node.type === "ExpressionStatement") {
+  //         await walk(node, {
+  //           enter() {
+  //             this.skip();
+  //           }
+  //         });
+  //       }
 
-		assert.ok(true);
-	});
+  //       if (node.type === "Identifier") {
+  //         identifiers.push(node.name);
+  //       }
+  //     }
+  //   });
 
-	it('allows walk() to be invoked within a walk, without context corruption', () => {
-		const ast = {
-			type: 'Program',
-			start: 0,
-			end: 8,
-			body: [{
-				type: 'ExpressionStatement',
-				start: 0,
-				end: 6,
-				expression: {
-					type: 'BinaryExpression',
-					start: 0,
-					end: 5,
-					left: {
-						type: 'Identifier',
-						start: 0,
-						end: 1,
-						name: 'a'
-					},
-					operator: '+',
-					right: {
-						type: 'Identifier',
-						start: 4,
-						end: 5,
-						name: 'b'
-					}
-				}
-			}],
-			sourceType: 'module'
-		};
+  //   assert.deepEqual(identifiers, ["a", "b"]);
+  // });
 
-		const identifiers = [];
+  // it("replaces a node", async () => {
+  //   const phases = ["enter", "leave"];
+  //   for await (const phase of phases) {
+  //     const ast = {
+  //       type: "Program",
+  //       start: 0,
+  //       end: 8,
+  //       body: [
+  //         {
+  //           type: "ExpressionStatement",
+  //           start: 0,
+  //           end: 6,
+  //           expression: {
+  //             type: "BinaryExpression",
+  //             start: 0,
+  //             end: 5,
+  //             left: {
+  //               type: "Identifier",
+  //               start: 0,
+  //               end: 1,
+  //               name: "a"
+  //             },
+  //             operator: "+",
+  //             right: {
+  //               type: "Identifier",
+  //               start: 4,
+  //               end: 5,
+  //               name: "b"
+  //             }
+  //           }
+  //         }
+  //       ],
+  //       sourceType: "module"
+  //     };
 
-		walk(ast, {
-			enter(node) {
-				if (node.type === 'ExpressionStatement') {
-					walk(node, {
-						enter() {
-							this.skip();
-						}
-					});
-				}
+  //     const forty_two = {
+  //       type: "Literal",
+  //       value: 42,
+  //       raw: "42"
+  //     };
 
-				if (node.type === 'Identifier') {
-					identifiers.push(node.name);
-				}
-			}
-		});
+  //     await walk(ast, {
+  //       [phase](node) {
+  //         if (node.type === "Identifier" && node.name === "b") {
+  //           this.replace(forty_two);
+  //         }
+  //       }
+  //     });
 
-		assert.deepEqual(identifiers, ['a', 'b']);
-	});
+  //     assert.equal(ast.body[0].expression.right, forty_two);
+  //   }
+  // });
 
-	it('replaces a node', () => {
-		['enter', 'leave'].forEach(phase => {
-			const ast = {
-				type: 'Program',
-				start: 0,
-				end: 8,
-				body: [{
-					type: 'ExpressionStatement',
-					start: 0,
-					end: 6,
-					expression: {
-						type: 'BinaryExpression',
-						start: 0,
-						end: 5,
-						left: {
-							type: 'Identifier',
-							start: 0,
-							end: 1,
-							name: 'a'
-						},
-						operator: '+',
-						right: {
-							type: 'Identifier',
-							start: 4,
-							end: 5,
-							name: 'b'
-						}
-					}
-				}],
-				sourceType: 'module'
-			};
+  // it("replaces a top-level node", async () => {
+  //   const ast = {
+  //     type: "Identifier",
+  //     name: "answer"
+  //   };
 
-			const forty_two = {
-				type: 'Literal',
-				value: 42,
-				raw: '42'
-			};
+  //   const forty_two = {
+  //     type: "Literal",
+  //     value: 42,
+  //     raw: "42"
+  //   };
 
-			walk(ast, {
-				[phase](node) {
-					if (node.type === 'Identifier' && node.name === 'b') {
-						this.replace(forty_two);
-					}
-				}
-			});
+  //   const node = await walk(ast, {
+  //     enter(node) {
+  //       if (node.type === "Identifier" && node.name === "answer") {
+  //         this.replace(forty_two);
+  //       }
+  //     }
+  //   });
 
-			assert.equal(ast.body[0].expression.right, forty_two);
-		});
-	});
+  //   assert.equal(node, forty_two);
+  // });
 
-	it('replaces a top-level node', () => {
-		const ast = {
-			type: 'Identifier',
-			name: 'answer'
-		};
+  // it("removes a node property", async () => {
+  //   const phases = ["enter", "leave"];
+  //   for await (const phase of phases) {
+  //     const ast = {
+  //       type: "Program",
+  //       start: 0,
+  //       end: 8,
+  //       body: [
+  //         {
+  //           type: "ExpressionStatement",
+  //           start: 0,
+  //           end: 6,
+  //           expression: {
+  //             type: "BinaryExpression",
+  //             start: 0,
+  //             end: 5,
+  //             left: {
+  //               type: "Identifier",
+  //               start: 0,
+  //               end: 1,
+  //               name: "a"
+  //             },
+  //             operator: "+",
+  //             right: {
+  //               type: "Identifier",
+  //               start: 4,
+  //               end: 5,
+  //               name: "b"
+  //             }
+  //           }
+  //         }
+  //       ],
+  //       sourceType: "module"
+  //     };
 
-		const forty_two = {
-			type: 'Literal',
-			value: 42,
-			raw: '42'
-		};
+  //     await walk(ast, {
+  //       [phase](node) {
+  //         if (node.type === "Identifier" && node.name === "b") {
+  //           this.remove();
+  //         }
+  //       }
+  //     });
 
-		const node = walk(ast, {
-			enter(node) {
-				if (node.type === 'Identifier' && node.name === 'answer') {
-					this.replace(forty_two);
-				}
-			}
-		});
+  //     assert.equal(ast.body[0].expression.right, undefined);
+  //   }
+  // });
 
-		assert.equal(node, forty_two);
-	});
+  // it("removes a node from array", async () => {
+	// 	const phases = ['enter', 'leave'];
+	// 	for await (const phase of phases) {
+  //     const ast = {
+  //       type: "Program",
+  //       body: [
+  //         {
+  //           type: "VariableDeclaration",
+  //           declarations: [
+  //             {
+  //               type: "VariableDeclarator",
+  //               id: {
+  //                 type: "Identifier",
+  //                 name: "a"
+  //               },
+  //               init: null
+  //             },
+  //             {
+  //               type: "VariableDeclarator",
+  //               id: {
+  //                 type: "Identifier",
+  //                 name: "b"
+  //               },
+  //               init: null
+  //             },
+  //             {
+  //               type: "VariableDeclarator",
+  //               id: {
+  //                 type: "Identifier",
+  //                 name: "c"
+  //               },
+  //               init: null
+  //             }
+  //           ],
+  //           kind: "let"
+  //         }
+  //       ],
+  //       sourceType: "module"
+  //     };
 
-	it('removes a node property', () => {
-		['enter', 'leave'].forEach(phase => {
-			const ast = {
-				type: 'Program',
-				start: 0,
-				end: 8,
-				body: [{
-					type: 'ExpressionStatement',
-					start: 0,
-					end: 6,
-					expression: {
-						type: 'BinaryExpression',
-						start: 0,
-						end: 5,
-						left: {
-							type: 'Identifier',
-							start: 0,
-							end: 1,
-							name: 'a'
-						},
-						operator: '+',
-						right: {
-							type: 'Identifier',
-							start: 4,
-							end: 5,
-							name: 'b'
-						}
-					}
-				}],
-				sourceType: 'module'
-			};
+  //     const visitedIndex = [];
 
-			walk(ast, {
-				[phase](node) {
-					if (node.type === 'Identifier' && node.name === 'b') {
-						this.remove();
-					}
-				}
-			});
+  //     walk(ast, {
+  //       [phase](node, parent, key, index) {
+  //         if (node.type === "VariableDeclarator") {
+  //           visitedIndex.push(index);
+  //           if (index === 1) {
+  //             this.remove();
+  //           }
+  //         }
+  //       }
+  //     });
 
-			assert.equal(ast.body[0].expression.right, undefined);
-		});
-	})
-
-	it('removes a node from array', () => {
-		['enter', 'leave'].forEach(phase => {
-			const ast = {
-				type: 'Program',
-				body: [{
-					type: 'VariableDeclaration',
-					declarations: [{
-						type: 'VariableDeclarator',
-						id: {
-							type: 'Identifier',
-							name: 'a',
-						},
-						init: null
-					},
-					{
-						type: 'VariableDeclarator',
-						id: {
-							type: 'Identifier',
-							name: 'b',
-						},
-						init: null
-					},
-					{
-						type: 'VariableDeclarator',
-						id: {
-							type: 'Identifier',
-							name: 'c',
-						},
-						init: null
-					}],
-					kind: 'let'
-				}],
-				sourceType: 'module'
-			};
-
-			const visitedIndex = [];
-
-			walk(ast, {
-				[phase](node, parent, key, index) {
-					if (node.type === 'VariableDeclarator') {
-						visitedIndex.push(index);
-						if (index === 1) {
-							this.remove();
-						}
-					}
-				}
-			});
-
-			assert.equal(ast.body[0].declarations.length, 2);
-			assert.equal(visitedIndex.length, 3);
-			assert.deepEqual(visitedIndex, [0, 1, 2]);
-			assert.equal(ast.body[0].declarations[0].id.name, 'a');
-			assert.equal(ast.body[0].declarations[1].id.name, 'c');
-		});
-	})
+  //     assert.equal(ast.body[0].declarations.length, 2);
+  //     assert.equal(visitedIndex.length, 3);
+  //     assert.deepEqual(visitedIndex, [0, 1, 2]);
+  //     assert.equal(ast.body[0].declarations[0].id.name, "a");
+  //     assert.equal(ast.body[0].declarations[1].id.name, "c");
+  //   };
+  // });
 });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4,10 +4,10 @@ declare type WalkerContext = {
     remove: () => void;
     replace: (node: BaseNode) => void;
 };
-declare type WalkerHandler = (this: WalkerContext, node: BaseNode, parent: BaseNode, key: string, index: number) => void;
+declare type WalkerHandler = (this: WalkerContext, node: BaseNode, parent: BaseNode, key: string, index: number) => Promise<void>;
 declare type Walker = {
     enter?: WalkerHandler;
     leave?: WalkerHandler;
 };
-export declare function walk(ast: BaseNode, { enter, leave }: Walker): BaseNode;
+export declare function walk(ast: BaseNode, { enter, leave }: Walker): Promise<BaseNode>;
 export {};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,88 +2,20 @@
 # yarn lockfile v1
 
 
-acorn-jsx@^3.0.0, acorn-jsx@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-3.0.1.tgz#afdf9488fb1ecefc8348f6fb22f464e32a58b36b"
-  dependencies:
-    acorn "^3.0.4"
+"@types/estree@0.0.39":
+  version "0.0.39"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
+  integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
 
-acorn-object-spread@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/acorn-object-spread/-/acorn-object-spread-1.0.0.tgz#48ead0f4a8eb16995a17a0db9ffc6acaada4ba68"
-  dependencies:
-    acorn "^3.1.0"
+"@types/node@*":
+  version "13.5.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.5.0.tgz#4e498dbf355795a611a87ae5ef811a8660d42662"
+  integrity sha512-Onhn+z72D2O2Pb2ql2xukJ55rglumsVo1H6Fmyi8mlU9SvKdBk/pUSUAiBY/d9bAOF7VVWajX3sths/+g6ZiAQ==
 
-acorn@^3.0.4, acorn@^3.1.0, acorn@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
-
-acorn@^5.5.0:
-  version "5.5.3"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.5.3.tgz#f473dd47e0277a08e28e9bec5aeeb04751f0b8c9"
-
-ajv-keywords@^2.1.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-2.1.1.tgz#617997fc5f60576894c435f940d819e135b80762"
-
-ajv@^5.2.3, ajv@^5.3.0:
-  version "5.5.2"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.2.tgz#73b5eeca3fab653e3d3f9422b341ad42205dc965"
-  dependencies:
-    co "^4.6.0"
-    fast-deep-equal "^1.0.0"
-    fast-json-stable-stringify "^2.0.0"
-    json-schema-traverse "^0.3.0"
-
-ansi-escapes@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.1.0.tgz#f73207bb81207d75fd6c83f125af26eea378ca30"
-
-ansi-regex@^2.0.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
-
-ansi-regex@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
-
-ansi-styles@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
-
-ansi-styles@^3.2.1:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
-  dependencies:
-    color-convert "^1.9.0"
-
-argparse@^1.0.7:
-  version "1.0.10"
-  resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
-  dependencies:
-    sprintf-js "~1.0.2"
-
-array-union@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/array-union/-/array-union-1.0.2.tgz#9a34410e4f4e3da23dea375be5be70f24778ec39"
-  dependencies:
-    array-uniq "^1.0.1"
-
-array-uniq@^1.0.1:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/array-uniq/-/array-uniq-1.0.3.tgz#af6ac877a25cc7f74e058894753858dfdb24fdb6"
-
-arrify@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
-
-babel-code-frame@^6.22.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
-  dependencies:
-    chalk "^1.1.3"
-    esutils "^2.0.2"
-    js-tokens "^3.0.2"
+any-promise@^1.0.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/any-promise/-/any-promise-1.3.0.tgz#abc6afeedcea52e809cdc0376aed3ce39635d17f"
+  integrity sha1-q8av7tzqUugJzcA3au0845Y10X8=
 
 balanced-match@^1.0.0:
   version "1.0.0"
@@ -96,312 +28,54 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
-browser-stdout@1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.0.tgz#f351d32969d32fa5d7a5567154263d928ae3bd1f"
+browser-stdout@1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.1.tgz#baa559ee14ced73452229bad7326467c61fabd60"
+  integrity sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==
 
-buble@^0.15.0, buble@^0.15.2:
-  version "0.15.2"
-  resolved "https://registry.yarnpkg.com/buble/-/buble-0.15.2.tgz#547fc47483f8e5e8176d82aa5ebccb183b02d613"
-  dependencies:
-    acorn "^3.3.0"
-    acorn-jsx "^3.0.1"
-    acorn-object-spread "^1.0.0"
-    chalk "^1.1.3"
-    magic-string "^0.14.0"
-    minimist "^1.2.0"
-    os-homedir "^1.0.1"
+commander@2.15.1:
+  version "2.15.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.15.1.tgz#df46e867d0fc2aec66a34662b406a9ccafff5b0f"
+  integrity sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==
 
-buffer-from@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.0.0.tgz#4cb8832d23612589b0406e9e2956c17f06fdf531"
-
-caller-path@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/caller-path/-/caller-path-0.1.0.tgz#94085ef63581ecd3daa92444a8fe94e82577751f"
-  dependencies:
-    callsites "^0.2.0"
-
-callsites@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/callsites/-/callsites-0.2.0.tgz#afab96262910a7f33c19a5775825c69f34e350ca"
-
-chalk@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
-  dependencies:
-    ansi-styles "^2.2.1"
-    escape-string-regexp "^1.0.2"
-    has-ansi "^2.0.0"
-    strip-ansi "^3.0.0"
-    supports-color "^2.0.0"
-
-chalk@^2.0.0, chalk@^2.1.0:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
-  dependencies:
-    ansi-styles "^3.2.1"
-    escape-string-regexp "^1.0.5"
-    supports-color "^5.3.0"
-
-chardet@^0.4.0:
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.4.2.tgz#b5473b33dc97c424e5d98dc87d55d4d8a29c8bf2"
-
-circular-json@^0.3.1:
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.3.tgz#815c99ea84f6809529d2f45791bdf82711352d66"
-
-cli-cursor@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-2.1.0.tgz#b35dac376479facc3e94747d41d0d0f5238ffcb5"
-  dependencies:
-    restore-cursor "^2.0.0"
-
-cli-width@^2.0.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.0.tgz#ff19ede8a9a5e579324147b0c11f0fbcbabed639"
-
-co@^4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
-
-color-convert@^1.9.0:
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.1.tgz#c1261107aeb2f294ebffec9ed9ecad529a6097ed"
-  dependencies:
-    color-name "^1.1.1"
-
-color-name@^1.1.1:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
-
-commander@2.9.0:
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
-  dependencies:
-    graceful-readlink ">= 1.0.0"
+commander@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.0.tgz#545983a0603fe425bc672d66c9e3c89c42121a83"
+  integrity sha512-NIQrwvv9V39FHgGFm36+U9SMQzbiHvU79k+iADraJTpmrFFfx7Ds0IvDoAdZsDrknlkRk14OYoWXb57uTh7/sw==
 
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
-concat-stream@^1.6.0:
-  version "1.6.2"
-  resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.2.tgz#904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34"
-  dependencies:
-    buffer-from "^1.0.0"
-    inherits "^2.0.3"
-    readable-stream "^2.2.2"
-    typedarray "^0.0.6"
-
-core-util-is@~1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
-
-cross-spawn@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
-  dependencies:
-    lru-cache "^4.0.1"
-    shebang-command "^1.2.0"
-    which "^1.2.9"
-
-debug@2.6.8:
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.8.tgz#e731531ca2ede27d188222427da17821d68ff4fc"
-  dependencies:
-    ms "2.0.0"
-
-debug@^3.1.0:
+debug@3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
   dependencies:
     ms "2.0.0"
 
-deep-is@~0.1.3:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
+diff@3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
+  integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
 
-del@^2.0.2:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/del/-/del-2.2.2.tgz#c12c981d067846c84bcaf862cff930d907ffd1a8"
-  dependencies:
-    globby "^5.0.0"
-    is-path-cwd "^1.0.0"
-    is-path-in-cwd "^1.0.0"
-    object-assign "^4.0.1"
-    pify "^2.0.0"
-    pinkie-promise "^2.0.0"
-    rimraf "^2.2.8"
-
-diff@3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-3.2.0.tgz#c9ce393a4b7cbd0b058a725c93df299027868ff9"
-
-doctrine@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"
-  dependencies:
-    esutils "^2.0.2"
-
-escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
+escape-string-regexp@1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
-eslint-scope@^3.7.1:
-  version "3.7.1"
-  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-3.7.1.tgz#3d63c3edfda02e06e01a452ad88caacc7cdcb6e8"
-  dependencies:
-    esrecurse "^4.1.0"
-    estraverse "^4.1.1"
-
-eslint-visitor-keys@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
-
-eslint@^4.5.0:
-  version "4.19.1"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.19.1.tgz#32d1d653e1d90408854bfb296f076ec7e186a300"
-  dependencies:
-    ajv "^5.3.0"
-    babel-code-frame "^6.22.0"
-    chalk "^2.1.0"
-    concat-stream "^1.6.0"
-    cross-spawn "^5.1.0"
-    debug "^3.1.0"
-    doctrine "^2.1.0"
-    eslint-scope "^3.7.1"
-    eslint-visitor-keys "^1.0.0"
-    espree "^3.5.4"
-    esquery "^1.0.0"
-    esutils "^2.0.2"
-    file-entry-cache "^2.0.0"
-    functional-red-black-tree "^1.0.1"
-    glob "^7.1.2"
-    globals "^11.0.1"
-    ignore "^3.3.3"
-    imurmurhash "^0.1.4"
-    inquirer "^3.0.6"
-    is-resolvable "^1.0.0"
-    js-yaml "^3.9.1"
-    json-stable-stringify-without-jsonify "^1.0.1"
-    levn "^0.3.0"
-    lodash "^4.17.4"
-    minimatch "^3.0.2"
-    mkdirp "^0.5.1"
-    natural-compare "^1.4.0"
-    optionator "^0.8.2"
-    path-is-inside "^1.0.2"
-    pluralize "^7.0.0"
-    progress "^2.0.0"
-    regexpp "^1.0.1"
-    require-uncached "^1.0.3"
-    semver "^5.3.0"
-    strip-ansi "^4.0.0"
-    strip-json-comments "~2.0.1"
-    table "4.0.2"
-    text-table "~0.2.0"
-
-espree@^3.5.4:
-  version "3.5.4"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-3.5.4.tgz#b0f447187c8a8bed944b815a660bddf5deb5d1a7"
-  dependencies:
-    acorn "^5.5.0"
-    acorn-jsx "^3.0.0"
-
-esprima@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.0.tgz#4499eddcd1110e0b218bacf2fa7f7f59f55ca804"
-
-esquery@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.0.1.tgz#406c51658b1f5991a5f9b62b1dc25b00e3e5c708"
-  dependencies:
-    estraverse "^4.0.0"
-
-esrecurse@^4.1.0:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.2.1.tgz#007a3b9fdbc2b3bb87e4879ea19c92fdbd3942cf"
-  dependencies:
-    estraverse "^4.1.0"
-
-estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
-
-estree-walker@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.2.1.tgz#bdafe8095383d8414d5dc2ecf4c9173b6db9412e"
-
-esutils@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
-
-external-editor@^2.0.4:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-2.2.0.tgz#045511cfd8d133f3846673d1047c154e214ad3d5"
-  dependencies:
-    chardet "^0.4.0"
-    iconv-lite "^0.4.17"
-    tmp "^0.0.33"
-
-fast-deep-equal@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz#c053477817c86b51daa853c81e059b733d023614"
-
-fast-json-stable-stringify@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
-
-fast-levenshtein@~2.0.4:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
-
-figures@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/figures/-/figures-2.0.0.tgz#3ab1a2d2a62c8bfb431a0c94cb797a2fce27c962"
-  dependencies:
-    escape-string-regexp "^1.0.5"
-
-file-entry-cache@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-2.0.0.tgz#c392990c3e684783d838b8c84a45d8a048458361"
-  dependencies:
-    flat-cache "^1.2.1"
-    object-assign "^4.0.1"
-
-flat-cache@^1.2.1:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-1.3.0.tgz#d3030b32b38154f4e3b7e9c709f490f7ef97c481"
-  dependencies:
-    circular-json "^0.3.1"
-    del "^2.0.2"
-    graceful-fs "^4.1.2"
-    write "^0.2.1"
+estree-walker@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.6.1.tgz#53049143f40c6eb918b23671d1fe3219f3a1b362"
+  integrity sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==
 
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
 
-functional-red-black-tree@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
-
-glob@7.1.1:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^3.0.2"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
-glob@^7.0.3, glob@^7.0.5, glob@^7.1.2:
+glob@7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
+  integrity sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -410,42 +84,10 @@ glob@^7.0.3, glob@^7.0.5, glob@^7.1.2:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-globals@^11.0.1:
-  version "11.5.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-11.5.0.tgz#6bc840de6771173b191f13d3a9c94d441ee92642"
-
-globby@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/globby/-/globby-5.0.0.tgz#ebd84667ca0dbb330b99bcfc68eac2bc54370e0d"
-  dependencies:
-    array-union "^1.0.1"
-    arrify "^1.0.0"
-    glob "^7.0.3"
-    object-assign "^4.0.1"
-    pify "^2.0.0"
-    pinkie-promise "^2.0.0"
-
-graceful-fs@^4.1.2:
-  version "4.1.11"
-  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
-
-"graceful-readlink@>= 1.0.0":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
-
-growl@1.9.2:
-  version "1.9.2"
-  resolved "https://registry.yarnpkg.com/growl/-/growl-1.9.2.tgz#0ea7743715db8d8de2c5ede1775e1b45ac85c02f"
-
-has-ansi@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/has-ansi/-/has-ansi-2.0.0.tgz#34f5049ce1ecdf2b0649af3ef24e45ed35416d91"
-  dependencies:
-    ansi-regex "^2.0.0"
-
-has-flag@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
+growl@1.10.5:
+  version "1.10.5"
+  resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.5.tgz#f2735dc2283674fa67478b10181059355c369e5e"
+  integrity sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==
 
 has-flag@^3.0.0:
   version "3.0.0"
@@ -455,20 +97,6 @@ he@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
 
-iconv-lite@^0.4.17:
-  version "0.4.21"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.21.tgz#c47f8733d02171189ebc4a400f3218d348094798"
-  dependencies:
-    safer-buffer "^2.1.0"
-
-ignore@^3.3.3:
-  version "3.3.8"
-  resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.8.tgz#3f8e9c35d38708a3a7e0e9abb6c73e7ee7707b2b"
-
-imurmurhash@^0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
-
 inflight@^1.0.4:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
@@ -476,166 +104,19 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.3, inherits@~2.0.3:
+inherits@2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
-inquirer@^3.0.6:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-3.3.0.tgz#9dd2f2ad765dcab1ff0443b491442a20ba227dc9"
-  dependencies:
-    ansi-escapes "^3.0.0"
-    chalk "^2.0.0"
-    cli-cursor "^2.1.0"
-    cli-width "^2.0.0"
-    external-editor "^2.0.4"
-    figures "^2.0.0"
-    lodash "^4.3.0"
-    mute-stream "0.0.7"
-    run-async "^2.2.0"
-    rx-lite "^4.0.8"
-    rx-lite-aggregates "^4.0.8"
-    string-width "^2.1.0"
-    strip-ansi "^4.0.0"
-    through "^2.3.6"
+lines-and-columns@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
+  integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
 
-is-fullwidth-code-point@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
-
-is-path-cwd@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-path-cwd/-/is-path-cwd-1.0.0.tgz#d225ec23132e89edd38fda767472e62e65f1106d"
-
-is-path-in-cwd@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz#5ac48b345ef675339bd6c7a48a912110b241cf52"
-  dependencies:
-    is-path-inside "^1.0.0"
-
-is-path-inside@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-1.0.1.tgz#8ef5b7de50437a3fdca6b4e865ef7aa55cb48036"
-  dependencies:
-    path-is-inside "^1.0.1"
-
-is-promise@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
-
-is-resolvable@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.1.0.tgz#fb18f87ce1feb925169c9a407c19318a3206ed88"
-
-isarray@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
-
-isexe@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
-
-js-tokens@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
-
-js-yaml@^3.9.1:
-  version "3.11.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.11.0.tgz#597c1a8bd57152f26d622ce4117851a51f5ebaef"
-  dependencies:
-    argparse "^1.0.7"
-    esprima "^4.0.0"
-
-json-schema-traverse@^0.3.0:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz#349a6d44c53a51de89b40805c5d5e59b417d3340"
-
-json-stable-stringify-without-jsonify@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
-
-json3@3.3.2:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/json3/-/json3-3.3.2.tgz#3c0434743df93e2f5c42aee7b19bcb483575f4e1"
-
-levn@^0.3.0, levn@~0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"
-  dependencies:
-    prelude-ls "~1.1.2"
-    type-check "~0.3.2"
-
-lodash._baseassign@^3.0.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz#8c38a099500f215ad09e59f1722fd0c52bfe0a4e"
-  dependencies:
-    lodash._basecopy "^3.0.0"
-    lodash.keys "^3.0.0"
-
-lodash._basecopy@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz#8da0e6a876cf344c0ad8a54882111dd3c5c7ca36"
-
-lodash._basecreate@^3.0.0:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz#1bc661614daa7fc311b7d03bf16806a0213cf821"
-
-lodash._getnative@^3.0.0:
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
-
-lodash._isiterateecall@^3.0.0:
-  version "3.0.9"
-  resolved "https://registry.yarnpkg.com/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz#5203ad7ba425fae842460e696db9cf3e6aac057c"
-
-lodash.create@3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/lodash.create/-/lodash.create-3.1.1.tgz#d7f2849f0dbda7e04682bb8cd72ab022461debe7"
-  dependencies:
-    lodash._baseassign "^3.0.0"
-    lodash._basecreate "^3.0.0"
-    lodash._isiterateecall "^3.0.0"
-
-lodash.isarguments@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz#2f573d85c6a24289ff00663b491c1d338ff3458a"
-
-lodash.isarray@^3.0.0:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-3.0.4.tgz#79e4eb88c36a8122af86f844aa9bcd851b5fbb55"
-
-lodash.keys@^3.0.0:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/lodash.keys/-/lodash.keys-3.1.2.tgz#4dbc0472b156be50a0b286855d1bd0b0c656098a"
-  dependencies:
-    lodash._getnative "^3.0.0"
-    lodash.isarguments "^3.0.0"
-    lodash.isarray "^3.0.0"
-
-lodash@^4.17.4, lodash@^4.3.0:
-  version "4.17.10"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
-
-lru-cache@^4.0.1:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.2.tgz#45234b2e6e2f2b33da125624c4664929a0224c3f"
-  dependencies:
-    pseudomap "^1.0.2"
-    yallist "^2.1.2"
-
-magic-string@^0.14.0:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.14.0.tgz#57224aef1701caeed273b17a39a956e72b172462"
-  dependencies:
-    vlq "^0.2.1"
-
-mimic-fn@^1.0.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
-
-minimatch@^3.0.2, minimatch@^3.0.4:
+minimatch@3.0.4, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
+  integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
   dependencies:
     brace-expansion "^1.1.7"
 
@@ -643,44 +124,46 @@ minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
-minimist@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
-
-mkdirp@0.5.1, mkdirp@^0.5.1:
+mkdirp@0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
     minimist "0.0.8"
 
-mocha@^3.5.0:
-  version "3.5.3"
-  resolved "https://registry.yarnpkg.com/mocha/-/mocha-3.5.3.tgz#1e0480fe36d2da5858d1eb6acc38418b26eaa20d"
+mocha@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-5.2.0.tgz#6d8ae508f59167f940f2b5b3c4a612ae50c90ae6"
+  integrity sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==
   dependencies:
-    browser-stdout "1.3.0"
-    commander "2.9.0"
-    debug "2.6.8"
-    diff "3.2.0"
+    browser-stdout "1.3.1"
+    commander "2.15.1"
+    debug "3.1.0"
+    diff "3.5.0"
     escape-string-regexp "1.0.5"
-    glob "7.1.1"
-    growl "1.9.2"
+    glob "7.1.2"
+    growl "1.10.5"
     he "1.1.1"
-    json3 "3.3.2"
-    lodash.create "3.1.1"
+    minimatch "3.0.4"
     mkdirp "0.5.1"
-    supports-color "3.1.2"
+    supports-color "5.4.0"
 
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
 
-mute-stream@0.0.7:
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
+mz@^2.7.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/mz/-/mz-2.7.0.tgz#95008057a56cafadc2bc63dde7f9ff6955948e32"
+  integrity sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==
+  dependencies:
+    any-promise "^1.0.0"
+    object-assign "^4.0.1"
+    thenify-all "^1.0.0"
 
-natural-compare@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
+node-modules-regexp@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz#8d9dbe28964a4ac5712e9131642107c71e90ec40"
+  integrity sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=
 
 object-assign@^4.0.1:
   version "4.1.1"
@@ -692,291 +175,82 @@ once@^1.3.0:
   dependencies:
     wrappy "1"
 
-onetime@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/onetime/-/onetime-2.0.1.tgz#067428230fd67443b2794b22bba528b6867962d4"
-  dependencies:
-    mimic-fn "^1.0.0"
-
-optionator@^0.8.2:
-  version "0.8.2"
-  resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.2.tgz#364c5e409d3f4d6301d6c0b4c05bba50180aeb64"
-  dependencies:
-    deep-is "~0.1.3"
-    fast-levenshtein "~2.0.4"
-    levn "~0.3.0"
-    prelude-ls "~1.1.2"
-    type-check "~0.3.2"
-    wordwrap "~1.0.0"
-
-os-homedir@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
-
-os-tmpdir@~1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
-
 path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
 
-path-is-inside@^1.0.1, path-is-inside@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
-
-pify@^2.0.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
-
-pinkie-promise@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/pinkie-promise/-/pinkie-promise-2.0.1.tgz#2135d6dfa7a358c069ac9b178776288228450ffa"
+pirates@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.1.tgz#643a92caf894566f91b2b986d2c66950a8e2fb87"
+  integrity sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==
   dependencies:
-    pinkie "^2.0.0"
+    node-modules-regexp "^1.0.0"
 
-pinkie@^2.0.0:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
-
-pluralize@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-7.0.0.tgz#298b89df8b93b0221dbf421ad2b1b1ea23fc6777"
-
-prelude-ls@~1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
-
-process-nextick-args@~2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
-
-progress@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.0.tgz#8a1be366bf8fc23db2bd23f10c6fe920b4389d1f"
-
-pseudomap@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
-
-readable-stream@^2.2.2:
-  version "2.3.6"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
+rollup-plugin-sucrase@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-sucrase/-/rollup-plugin-sucrase-2.1.0.tgz#4c5e1e3b002050bad64b44890b0c2959f3efe35b"
+  integrity sha512-chdA3OruR1FH/IIKrzZCpGKLXAx3DOHoK24RIPtlVccK0wbTpHE0HpGEQYCxte1XaB17NgRe/frFyKR7g45qxQ==
   dependencies:
-    core-util-is "~1.0.0"
-    inherits "~2.0.3"
-    isarray "~1.0.0"
-    process-nextick-args "~2.0.0"
-    safe-buffer "~5.1.1"
-    string_decoder "~1.1.1"
-    util-deprecate "~1.0.1"
+    rollup-pluginutils "^2.3.0"
+    sucrase "3.x"
 
-regexpp@^1.0.1:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-1.1.0.tgz#0e3516dd0b7904f413d2d4193dce4618c3a689ab"
-
-require-uncached@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/require-uncached/-/require-uncached-1.0.3.tgz#4e0d56d6c9662fd31e43011c4b95aa49955421d3"
+rollup-pluginutils@^2.3.0:
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz#72f2af0748b592364dbd3389e600e5a9444a351e"
+  integrity sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==
   dependencies:
-    caller-path "^0.1.0"
-    resolve-from "^1.0.0"
+    estree-walker "^0.6.1"
 
-resolve-from@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
-
-restore-cursor@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-2.0.0.tgz#9f7ee287f82fd326d4fd162923d62129eee0dfaf"
+rollup@^0.67.3:
+  version "0.67.4"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.67.4.tgz#8ed6b0993337f84ec8a0387f824fa6c197e833ec"
+  integrity sha512-AVuP73mkb4BBMUmksQ3Jw0jTrBTU1i7rLiUYjFxLZGb3xiFmtVEg40oByphkZAsiL0bJC3hRAJUQos/e5EBd+w==
   dependencies:
-    onetime "^2.0.0"
-    signal-exit "^3.0.2"
+    "@types/estree" "0.0.39"
+    "@types/node" "*"
 
-rimraf@^2.2.8:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
+sucrase@3.x:
+  version "3.12.1"
+  resolved "https://registry.yarnpkg.com/sucrase/-/sucrase-3.12.1.tgz#85888fb0c3c39e3723b720690b6db2bde7b34c5c"
+  integrity sha512-aYG1RVImoyczRm/puVkNjbWZFus2b/LJj58RWEF7oe4XcKu/a/rudq+R9OrO69juzVx6KnPGTvjWUbIGnXTeFA==
   dependencies:
-    glob "^7.0.5"
+    commander "^4.0.0"
+    lines-and-columns "^1.1.6"
+    mz "^2.7.0"
+    pirates "^4.0.1"
+    ts-interface-checker "^0.1.9"
 
-rollup-plugin-buble@^0.15.0:
-  version "0.15.0"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-buble/-/rollup-plugin-buble-0.15.0.tgz#83c3e89c7fd2266c7918f41ba3980313519c7fd0"
-  dependencies:
-    buble "^0.15.0"
-    rollup-pluginutils "^1.5.0"
-
-rollup-pluginutils@^1.5.0:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-1.5.2.tgz#1e156e778f94b7255bfa1b3d0178be8f5c552408"
-  dependencies:
-    estree-walker "^0.2.1"
-    minimatch "^3.0.2"
-
-rollup@^0.48.0:
-  version "0.48.2"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.48.2.tgz#dd9214eaf78d98a7771bf5583123cc80a0b5d6dc"
-
-run-async@^2.2.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.3.0.tgz#0371ab4ae0bdd720d4166d7dfda64ff7a445a6c0"
-  dependencies:
-    is-promise "^2.1.0"
-
-rx-lite-aggregates@^4.0.8:
-  version "4.0.8"
-  resolved "https://registry.yarnpkg.com/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz#753b87a89a11c95467c4ac1626c4efc4e05c67be"
-  dependencies:
-    rx-lite "*"
-
-rx-lite@*, rx-lite@^4.0.8:
-  version "4.0.8"
-  resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-4.0.8.tgz#0b1e11af8bc44836f04a6407e92da42467b79444"
-
-safe-buffer@~5.1.0, safe-buffer@~5.1.1:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
-
-safer-buffer@^2.1.0:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
-
-semver@^5.3.0:
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
-
-shebang-command@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
-  dependencies:
-    shebang-regex "^1.0.0"
-
-shebang-regex@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
-
-signal-exit@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
-
-slice-ansi@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-1.0.0.tgz#044f1a49d8842ff307aad6b505ed178bd950134d"
-  dependencies:
-    is-fullwidth-code-point "^2.0.0"
-
-sprintf-js@~1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
-
-string-width@^2.1.0, string-width@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
-  dependencies:
-    is-fullwidth-code-point "^2.0.0"
-    strip-ansi "^4.0.0"
-
-string_decoder@~1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
-  dependencies:
-    safe-buffer "~5.1.0"
-
-strip-ansi@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
-  dependencies:
-    ansi-regex "^2.0.0"
-
-strip-ansi@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f"
-  dependencies:
-    ansi-regex "^3.0.0"
-
-strip-json-comments@~2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
-
-supports-color@3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.1.2.tgz#72a262894d9d408b956ca05ff37b2ed8a6e2a2d5"
-  dependencies:
-    has-flag "^1.0.0"
-
-supports-color@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
-
-supports-color@^5.3.0:
+supports-color@5.4.0:
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.4.0.tgz#1c6b337402c2137605efe19f10fec390f6faab54"
+  integrity sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==
   dependencies:
     has-flag "^3.0.0"
 
-table@4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/table/-/table-4.0.2.tgz#a33447375391e766ad34d3486e6e2aedc84d2e36"
+thenify-all@^1.0.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/thenify-all/-/thenify-all-1.6.0.tgz#1a1918d402d8fc3f98fbf234db0bcc8cc10e9726"
+  integrity sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=
   dependencies:
-    ajv "^5.2.3"
-    ajv-keywords "^2.1.0"
-    chalk "^2.1.0"
-    lodash "^4.17.4"
-    slice-ansi "1.0.0"
-    string-width "^2.1.1"
+    thenify ">= 3.1.0 < 4"
 
-text-table@~0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
-
-through@^2.3.6:
-  version "2.3.8"
-  resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
-
-tmp@^0.0.33:
-  version "0.0.33"
-  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
+"thenify@>= 3.1.0 < 4":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/thenify/-/thenify-3.3.0.tgz#e69e38a1babe969b0108207978b9f62b88604839"
+  integrity sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=
   dependencies:
-    os-tmpdir "~1.0.2"
+    any-promise "^1.0.0"
 
-type-check@~0.3.2:
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
-  dependencies:
-    prelude-ls "~1.1.2"
+ts-interface-checker@^0.1.9:
+  version "0.1.10"
+  resolved "https://registry.yarnpkg.com/ts-interface-checker/-/ts-interface-checker-0.1.10.tgz#b68a49e37e90a05797e590f08494dd528bf383cf"
+  integrity sha512-UJYuKET7ez7ry0CnvfY6fPIUIZDw+UI3qvTUQeS2MyI4TgEeWAUBqy185LeaHcdJ9zG2dgFpPJU/AecXU0Afug==
 
-typedarray@^0.0.6:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
-
-util-deprecate@~1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
-
-vlq@^0.2.1:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/vlq/-/vlq-0.2.3.tgz#8f3e4328cf63b1540c0d67e1b2778386f8975b26"
-
-which@^1.2.9:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/which/-/which-1.3.0.tgz#ff04bdfc010ee547d780bec38e1ac1c2777d253a"
-  dependencies:
-    isexe "^2.0.0"
-
-wordwrap@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
+typescript@^3.6.3:
+  version "3.7.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.5.tgz#0692e21f65fd4108b9330238aac11dd2e177a1ae"
+  integrity sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==
 
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
-
-write@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/write/-/write-0.2.1.tgz#5fc03828e264cea3fe91455476f7a3c566cb0757"
-  dependencies:
-    mkdirp "^0.5.1"
-
-yallist@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"


### PR DESCRIPTION
Note: I ended up needing to do this, but you might not want this in the default case.

Reason:
1. Using `estree-walk` during the `transform` lifecycle of a rollup plugin. 
2. This `transform` needed to know the resolved id of an imported member.
3. rollup resolver is Promise based, `await this.context.resolve(name, id)`

:man_shrugging: 