### PR TITLE
Add native node es modules support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,12 +10,6 @@
       "integrity": "sha512-K1DPVvnBCPxzD+G51/cxVIoc2X8uUVl1zpJeE6iKcgHMj4+tbat5Xu4TjV7v2QSDbIeAfLi2hIk+u2+s0MlpUQ==",
       "dev": true
     },
-    "@types/node": {
-      "version": "13.7.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.7.0.tgz",
-      "integrity": "sha512-GnZbirvmqZUzMgkFn70c74OQpTTUcCzlhQliTzYjQMqg+hVKcDnxdL19Ne3UdYzdMA/+W3eb646FWn/ZaT1NfQ==",
-      "dev": true
-    },
     "any-promise": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
@@ -88,6 +82,13 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
+    },
+    "fsevents": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+      "dev": true,
+      "optional": true
     },
     "glob": {
       "version": "7.1.2",
@@ -240,21 +241,12 @@
       }
     },
     "rollup": {
-      "version": "0.67.4",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.67.4.tgz",
-      "integrity": "sha512-AVuP73mkb4BBMUmksQ3Jw0jTrBTU1i7rLiUYjFxLZGb3xiFmtVEg40oByphkZAsiL0bJC3hRAJUQos/e5EBd+w==",
+      "version": "2.10.9",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.10.9.tgz",
+      "integrity": "sha512-dY/EbjiWC17ZCUSyk14hkxATAMAShkMsD43XmZGWjLrgFj15M3Dw2kEkA9ns64BiLFm9PKN6vTQw8neHwK74eg==",
       "dev": true,
       "requires": {
-        "@types/estree": "0.0.39",
-        "@types/node": "*"
-      },
-      "dependencies": {
-        "@types/estree": {
-          "version": "0.0.39",
-          "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
-          "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
-          "dev": true
-        }
+        "fsevents": "~2.1.2"
       }
     },
     "rollup-plugin-sucrase": {
@@ -277,12 +269,13 @@
       }
     },
     "sucrase": {
-      "version": "3.12.1",
-      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.12.1.tgz",
-      "integrity": "sha512-aYG1RVImoyczRm/puVkNjbWZFus2b/LJj58RWEF7oe4XcKu/a/rudq+R9OrO69juzVx6KnPGTvjWUbIGnXTeFA==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.15.0.tgz",
+      "integrity": "sha512-05TJOUfMgckH7wKqfk/1p4G6q16nIeW/GHQwD44vkT0mQMqqzgfHCwkX3whNmwyOo7nVF0jDLwVu/qOBTtsscw==",
       "dev": true,
       "requires": {
         "commander": "^4.0.0",
+        "glob": "7.1.6",
         "lines-and-columns": "^1.1.6",
         "mz": "^2.7.0",
         "pirates": "^4.0.1",
@@ -294,6 +287,20 @@
           "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
           "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
           "dev": true
+        },
+        "glob": {
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
         }
       }
     },
@@ -325,9 +332,9 @@
       }
     },
     "ts-interface-checker": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.10.tgz",
-      "integrity": "sha512-UJYuKET7ez7ry0CnvfY6fPIUIZDw+UI3qvTUQeS2MyI4TgEeWAUBqy185LeaHcdJ9zG2dgFpPJU/AecXU0Afug==",
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.11.tgz",
+      "integrity": "sha512-Jx6cFBiuCQrRl3CgoIOamIE/toZ8jQJbIlsLGpkBiUpCEUyFcyZ2pvjP8kSXIcz8V5v/murgm/5EfIQapUmh6A==",
       "dev": true
     },
     "typescript": {

--- a/package.json
+++ b/package.json
@@ -9,8 +9,13 @@
     "type": "git",
     "url": "https://github.com/Rich-Harris/estree-walker"
   },
-  "main": "dist/estree-walker.umd.js",
-  "module": "src/estree-walker.js",
+  "type": "commonjs",
+  "main": "./dist/umd/estree-walker.js",
+  "module": "./dist/es/estree-walker.js",
+  "exports": {
+    "require": "./dist/umd/estree-walker.js",
+    "import": "./dist/es/estree-walker.js"
+  },
   "types": "types/index.d.ts",
   "scripts": {
     "prepublishOnly": "npm run build && npm test",
@@ -20,7 +25,7 @@
   "devDependencies": {
     "@types/estree": "0.0.42",
     "mocha": "^5.2.0",
-    "rollup": "^0.67.3",
+    "rollup": "^2.10.9",
     "rollup-plugin-sucrase": "^2.1.0",
     "typescript": "^3.7.5"
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,11 +1,24 @@
 import sucrase from 'rollup-plugin-sucrase';
 import pkg from './package.json';
 
+function emitModulePackageFile() {
+  return {
+    name: 'emit-module-package-file',
+    generateBundle() {
+      this.emitFile({
+        type: 'asset',
+        fileName: 'package.json',
+        source: `{"type":"module"}`
+      });
+    }
+  };
+}
+
 export default {
 	input: 'src/index.ts',
 	output: [
 		{ file: pkg.main, format: 'umd', name: 'estreeWalker' },
-		{ file: pkg.module, format: 'esm' }
+		{ file: pkg.module, format: 'esm', plugins: [emitModulePackageFile] }
 	],
 	plugins: [
 		sucrase({


### PR DESCRIPTION
A blocker for https://github.com/rollup/plugins/pull/419

emitModulePackageFile is used to avoid .mjs extension.