### PR TITLE
Replace BaseNode with Node

### DIFF
--- a/src/async.js
+++ b/src/async.js
@@ -1,13 +1,13 @@
 // @ts-check
 import { WalkerBase } from './walker.js';
 
-/** @typedef { import('estree').BaseNode} BaseNode */
-/** @typedef { import('./walker').WalkerContext} WalkerContext */
+/** @typedef { import('estree').Node } Node */
+/** @typedef { import('./walker').WalkerContext } WalkerContext */
 
 /** @typedef {(
  *    this: WalkerContext,
- *    node: BaseNode,
- *    parent: BaseNode,
+ *    node: Node,
+ *    parent: Node,
  *    key: string,
  *    index: number
  * ) => Promise<void>} AsyncHandler */
@@ -30,11 +30,11 @@ export class AsyncWalker extends WalkerBase {
 
 	/**
 	 *
-	 * @param {BaseNode} node
-	 * @param {BaseNode} parent
+	 * @param {Node} node
+	 * @param {Node} parent
 	 * @param {string} [prop]
 	 * @param {number} [index]
-	 * @returns {Promise<BaseNode>}
+	 * @returns {Promise<Node>}
 	 */
 	async visit(node, parent, prop, index) {
 		if (node) {

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import { SyncWalker } from './sync.js';
 import { AsyncWalker } from './async.js';
 
 /** @typedef { import('estree').Node } Node */
+/** @typedef { import('estree').BaseNode } BaseNode */
 /** @typedef { import('./sync.js').SyncHandler } SyncHandler */
 /** @typedef { import('./async.js').AsyncHandler } AsyncHandler */
 

--- a/src/index.js
+++ b/src/index.js
@@ -2,18 +2,18 @@
 import { SyncWalker } from './sync.js';
 import { AsyncWalker } from './async.js';
 
-/** @typedef { import('estree').BaseNode} BaseNode */
-/** @typedef { import('./sync.js').SyncHandler} SyncHandler */
-/** @typedef { import('./async.js').AsyncHandler} AsyncHandler */
+/** @typedef { import('estree').Node } Node */
+/** @typedef { import('./sync.js').SyncHandler } SyncHandler */
+/** @typedef { import('./async.js').AsyncHandler } AsyncHandler */
 
 /**
  *
- * @param {BaseNode} ast
+ * @param {Node} ast
  * @param {{
  *   enter?: SyncHandler
  *   leave?: SyncHandler
  * }} walker
- * @returns {BaseNode}
+ * @returns {Node}
  */
 export function walk(ast, { enter, leave }) {
 	const instance = new SyncWalker(enter, leave);
@@ -22,12 +22,12 @@ export function walk(ast, { enter, leave }) {
 
 /**
  *
- * @param {BaseNode} ast
+ * @param {Node} ast
  * @param {{
  *   enter?: AsyncHandler
  *   leave?: AsyncHandler
  * }} walker
- * @returns {Promise<BaseNode>}
+ * @returns {Promise<Node>}
  */
 export async function asyncWalk(ast, { enter, leave }) {
 	const instance = new AsyncWalker(enter, leave);

--- a/src/sync.js
+++ b/src/sync.js
@@ -1,13 +1,13 @@
 // @ts-check
 import { WalkerBase } from './walker.js';
 
-/** @typedef { import('estree').BaseNode} BaseNode */
-/** @typedef { import('./walker.js').WalkerContext} WalkerContext */
+/** @typedef { import('estree').Node } Node */
+/** @typedef { import('./walker.js').WalkerContext } WalkerContext */
 
 /** @typedef {(
  *    this: WalkerContext,
- *    node: BaseNode,
- *    parent: BaseNode,
+ *    node: Node,
+ *    parent: Node,
  *    key: string,
  *    index: number
  * ) => void} SyncHandler */
@@ -30,11 +30,11 @@ export class SyncWalker extends WalkerBase {
 
 	/**
 	 *
-	 * @param {BaseNode} node
-	 * @param {BaseNode} parent
+	 * @param {Node} node
+	 * @param {Node} parent
 	 * @param {string} [prop]
 	 * @param {number} [index]
-	 * @returns {BaseNode}
+	 * @returns {Node}
 	 */
 	visit(node, parent, prop, index) {
 		if (node) {

--- a/src/walker.js
+++ b/src/walker.js
@@ -1,10 +1,10 @@
 // @ts-check
-/** @typedef { import('estree').BaseNode} BaseNode */
+/** @typedef { import('estree').Node } Node */
 
 /** @typedef {{
 	skip: () => void;
 	remove: () => void;
-	replace: (node: BaseNode) => void;
+	replace: (node: Node) => void;
 }} WalkerContext */
 
 export class WalkerBase {
@@ -15,7 +15,7 @@ export class WalkerBase {
 		/** @type {boolean} */
 		this.should_remove = false;
 
-		/** @type {BaseNode | null} */
+		/** @type {Node | null} */
 		this.replacement = null;
 
 		/** @type {WalkerContext} */
@@ -31,7 +31,7 @@ export class WalkerBase {
 	 * @param {any} parent
 	 * @param {string} prop
 	 * @param {number} index
-	 * @param {BaseNode} node
+	 * @param {Node} node
 	 */
 	replace(parent, prop, index, node) {
 		if (parent) {


### PR DESCRIPTION
This will allow TypeScript to discriminate between BaseNode subclasses: 
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/47e54bb08dd1dc8d4c0f5cbc232d623c34245213/types/estree/index.d.ts#L38