### PR TITLE
fix(esm): add types conditional export

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "types": "./types/index.d.ts",
       "import": "./src/index.js"
     }
   },


### PR DESCRIPTION
Adds `types` conditional export in preparation for ESM support in TypeScript: [Failing Playground Link](https://www.typescriptlang.org/play?target=99&moduleResolution=99&ts=4.6.0-dev.20220116#code/JYWwDg9gTgLgBAbzgQwM4E8B2BjA6sgGwGs4BfOAMyghDgHIBTVGKBhgWgHdCiGo6A3EA)

I included it as the first item based on this clause in the docs: https://nodejs.org/api/packages.html#:~:text=This%20condition%20should%20always%20be%20included%20first.