### PR TITLE
fix: add CommonJS export to estree-walker package.json to resolve ERR…

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
 		"./package.json": "./package.json",
 		".": {
 			"types": "./types/index.d.ts",
-			"import": "./src/index.js"
+			"import": "./src/index.js",
+			"require": "./src/index.js"
 		}
 	},
 	"types": "types/index.d.ts",


### PR DESCRIPTION
…_PACKAGE_PATH_NOT_EXPORTED error

fixes #26 

The error ERR_PACKAGE_PATH_NOT_EXPORTED occurs because the estree-walker package does not have an appropriate export defined for CommonJS modules in its package.json file. By adding `"require": "./src/index.js"` to the exports field, you explicitly define the entry point for CommonJS modules, which resolves the issue.

```json
".": {
      "types": "./types/index.d.ts",
      "import": "./src/index.js",
      "require": "./src/index.js" 
    }
```