### PR TITLE
feat: add support for calling `leave` when skipping a node

### DIFF
--- a/src/sync.js
+++ b/src/sync.js
@@ -3,6 +3,7 @@ import { WalkerBase } from './walker.js';
 /**
  * @typedef { import('estree').Node} Node
  * @typedef { import('./walker.js').WalkerContext} WalkerContext
+ * @typedef { import('./walker.js').SkipOptions} SkipOptions
  * @typedef {(
  *    this: WalkerContext,
  *    node: Node,
@@ -21,8 +22,8 @@ export class SyncWalker extends WalkerBase {
 	constructor(enter, leave) {
 		super();
 
-		/** @type {boolean} */
-		this.should_skip = false;
+		/** @type {'no' | 'with-leave' | 'without-leave'} */
+		this.should_skip = 'no';
 
 		/** @type {boolean} */
 		this.should_remove = false;
@@ -32,7 +33,10 @@ export class SyncWalker extends WalkerBase {
 
 		/** @type {WalkerContext} */
 		this.context = {
-			skip: () => (this.should_skip = true),
+			/** @param {SkipOptions} options */
+			skip: (options = {}) => {
+				this.should_skip = options.callLeave ? 'with-leave' : 'without-leave';
+			},
 			remove: () => (this.should_remove = true),
 			replace: (node) => (this.replacement = node)
 		};
@@ -54,11 +58,13 @@ export class SyncWalker extends WalkerBase {
 	 */
 	visit(node, parent, prop, index) {
 		if (node) {
+			let skipStrategy = this.should_skip;
+
 			if (this.enter) {
 				const _should_skip = this.should_skip;
 				const _should_remove = this.should_remove;
 				const _replacement = this.replacement;
-				this.should_skip = false;
+				this.should_skip = 'no';
 				this.should_remove = false;
 				this.replacement = null;
 
@@ -73,38 +79,40 @@ export class SyncWalker extends WalkerBase {
 					this.remove(parent, prop, index);
 				}
 
-				const skipped = this.should_skip;
+				skipStrategy = this.should_skip;
 				const removed = this.should_remove;
 
 				this.should_skip = _should_skip;
 				this.should_remove = _should_remove;
 				this.replacement = _replacement;
 
-				if (skipped) return node;
+				if (skipStrategy === 'without-leave') return node;
 				if (removed) return null;
 			}
 
-			/** @type {keyof Node} */
-			let key;
+			if (skipStrategy === 'no') {
+				/** @type {keyof Node} */
+				let key;
 
-			for (key in node) {
-				/** @type {unknown} */
-				const value = node[key];
+				for (key in node) {
+					/** @type {unknown} */
+					const value = node[key];
 
-				if (value && typeof value === 'object') {
-					if (Array.isArray(value)) {
-						const nodes = /** @type {Array<unknown>} */ (value);
-						for (let i = 0; i < nodes.length; i += 1) {
-							const item = nodes[i];
-							if (isNode(item)) {
-								if (!this.visit(item, node, key, i)) {
-									// removed
-									i--;
+					if (value && typeof value === 'object') {
+						if (Array.isArray(value)) {
+							const nodes = /** @type {Array<unknown>} */ (value);
+							for (let i = 0; i < nodes.length; i += 1) {
+								const item = nodes[i];
+								if (isNode(item)) {
+									if (!this.visit(item, node, key, i)) {
+										// removed
+										i--;
+									}
 								}
 							}
+						} else if (isNode(value)) {
+							this.visit(value, node, key, null);
 						}
-					} else if (isNode(value)) {
-						this.visit(value, node, key, null);
 					}
 				}
 			}

--- a/src/walker.js
+++ b/src/walker.js
@@ -1,7 +1,10 @@
 /**
  * @typedef { import('estree').Node} Node
  * @typedef {{
- *   skip: () => void;
+ *   callLeave?: boolean;
+ * }} SkipOptions
+ * @typedef {{
+ *   skip: (options?: SkipOptions) => void;
  *   remove: () => void;
  *   replace: (node: Node) => void;
  * }} WalkerContext

--- a/test/test.mjs
+++ b/test/test.mjs
@@ -193,6 +193,126 @@ describe('sync estree-walker', it => {
 		assert.equal(identifiers, ['a', 'b']);
 	});
 
+	it('skips node\'s children when skip() is called', () => {
+		const ast = {
+			type: 'Program',
+			start: 0,
+			end: 8,
+			body: [
+				{
+					type: 'ExpressionStatement',
+					start: 0,
+					end: 6,
+					expression: {
+						type: 'BinaryExpression',
+						start: 0,
+						end: 5,
+						left: {
+							type: 'Identifier',
+							start: 0,
+							end: 1,
+							name: 'a'
+						},
+						operator: '+',
+						right: {
+							type: 'Identifier',
+							start: 4,
+							end: 5,
+							name: 'b'
+						}
+					}
+				}
+			],
+			sourceType: 'module'
+		};
+
+		const enteredNodeTypes = [];
+		const leftNodeTypes = [];
+
+		walk(ast, {
+			enter(node) {
+				enteredNodeTypes.push(node.type);
+
+				if (node.type === 'ExpressionStatement') {
+					this.skip();
+				}
+			},
+			leave(node) {
+				leftNodeTypes.push(node.type);
+			}
+		});
+
+		assert.equal(enteredNodeTypes, [
+			'Program',
+			'ExpressionStatement',
+		]);
+
+		assert.equal(leftNodeTypes, [
+			'Program'
+		]);
+	});
+
+	it('skips node\'s children when skip({ callLeave: true }) is called but still calls leave', () => {
+		const ast = {
+			type: 'Program',
+			start: 0,
+			end: 8,
+			body: [
+				{
+					type: 'ExpressionStatement',
+					start: 0,
+					end: 6,
+					expression: {
+						type: 'BinaryExpression',
+						start: 0,
+						end: 5,
+						left: {
+							type: 'Identifier',
+							start: 0,
+							end: 1,
+							name: 'a'
+						},
+						operator: '+',
+						right: {
+							type: 'Identifier',
+							start: 4,
+							end: 5,
+							name: 'b'
+						}
+					}
+				}
+			],
+			sourceType: 'module'
+		};
+
+		const enteredNodeTypes = [];
+		const leftNodeTypes = [];
+
+		walk(ast, {
+			enter(node) {
+				enteredNodeTypes.push(node.type);
+
+				if (node.type === 'ExpressionStatement') {
+					this.skip({ callLeave: true });
+				}
+			},
+			leave(node) {
+				leftNodeTypes.push(node.type);
+			}
+		});
+
+		assert.equal(enteredNodeTypes, [
+			'Program',
+			'ExpressionStatement',
+		]);
+
+		assert.equal(leftNodeTypes, [
+			'ExpressionStatement',
+			'Program',
+		]);
+	});
+
+
 	it('replaces a node', () => {
 		const phases = ['enter', 'leave'];
 		for (const phase of phases) {
@@ -560,6 +680,125 @@ describe('async estree-walker', it => {
 		});
 
 		assert.equal(identifiers, ['a', 'b']);
+	});
+
+	it('skips node\'s children when skip() is called', async () => {
+		const ast = {
+			type: 'Program',
+			start: 0,
+			end: 8,
+			body: [
+				{
+					type: 'ExpressionStatement',
+					start: 0,
+					end: 6,
+					expression: {
+						type: 'BinaryExpression',
+						start: 0,
+						end: 5,
+						left: {
+							type: 'Identifier',
+							start: 0,
+							end: 1,
+							name: 'a'
+						},
+						operator: '+',
+						right: {
+							type: 'Identifier',
+							start: 4,
+							end: 5,
+							name: 'b'
+						}
+					}
+				}
+			],
+			sourceType: 'module'
+		};
+
+		const enteredNodeTypes = [];
+		const leftNodeTypes = [];
+
+		await asyncWalk(ast, {
+			enter(node) {
+				enteredNodeTypes.push(node.type);
+
+				if (node.type === 'ExpressionStatement') {
+					this.skip();
+				}
+			},
+			leave(node) {
+				leftNodeTypes.push(node.type);
+			}
+		});
+
+		assert.equal(enteredNodeTypes, [
+			'Program',
+			'ExpressionStatement',
+		]);
+
+		assert.equal(leftNodeTypes, [
+			'Program'
+		]);
+	});
+
+	it('skips node\'s children when skip({ callLeave: true }) is called but still calls leave', async () => {
+		const ast = {
+			type: 'Program',
+			start: 0,
+			end: 8,
+			body: [
+				{
+					type: 'ExpressionStatement',
+					start: 0,
+					end: 6,
+					expression: {
+						type: 'BinaryExpression',
+						start: 0,
+						end: 5,
+						left: {
+							type: 'Identifier',
+							start: 0,
+							end: 1,
+							name: 'a'
+						},
+						operator: '+',
+						right: {
+							type: 'Identifier',
+							start: 4,
+							end: 5,
+							name: 'b'
+						}
+					}
+				}
+			],
+			sourceType: 'module'
+		};
+
+		const enteredNodeTypes = [];
+		const leftNodeTypes = [];
+
+		await asyncWalk(ast, {
+			enter(node) {
+				enteredNodeTypes.push(node.type);
+
+				if (node.type === 'ExpressionStatement') {
+					this.skip({ callLeave: true });
+				}
+			},
+			leave(node) {
+				leftNodeTypes.push(node.type);
+			}
+		});
+
+		assert.equal(enteredNodeTypes, [
+			'Program',
+			'ExpressionStatement',
+		]);
+
+		assert.equal(leftNodeTypes, [
+			'ExpressionStatement',
+			'Program',
+		]);
 	});
 
 	it('replaces a node', async () => {


### PR DESCRIPTION
resolves https://github.com/Rich-Harris/estree-walker/issues/41

It can be useful to skip a node while walking an AST, yet still invoke the `leave` callback for cleanup logic. In Nuxt, for example, we use `estree-walker` alongside a scope tracker that requires the `leave` callback to be triggered in order to track the scopes properly.

This PR adds the ability to skip a node while still calling the `leave` callback.

```ts
this.skip({ callLeave: true })
```

I'm open to suggestions regarding the API. I was also considering making it call `leave` by default, but that would obviously be a breaking change. 
Should we go in that direction, or keep the current behavior as the default?

----
Should I add this functionality for node removal as well? I can imagine the situation might be similar.